### PR TITLE
Fix output for integer values to truncate trailing decimal places

### DIFF
--- a/scripts/ethernet
+++ b/scripts/ethernet
@@ -20,7 +20,7 @@ def extract_speed(string):
     numeric_part = int(result.group())
     speed = numeric_part / 1000.0
     if speed.is_integer():
-        formatted_speed = f"{speed} Gb/s"
+        formatted_speed = f"{speed:.4g} Gb/s"
     else:
         formatted_speed = f"{speed:.1f} Gb/s"
     return formatted_speed


### PR DESCRIPTION
Fix output for integer values to truncate trailing decimal places. This will prevent "10 Gb/s" from showing as "10.0 Gb/s" for example.